### PR TITLE
Assets folder recognition fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ import { ArticleManager } from './logic/article-manager.js';
 import { validateDuplicatedOpeningHeading, validateHeadingsNesting, validateMaxLength, validateNumberedHeadings, validateOpeningHeadingLevel, validateSpacing, validateTitleCase } from './validations/headings.js'
 import { validateMetaData } from './validations/metadata.js';
 import { validateRules } from './validations/rules.js';
-import { validateImageDescriptions, validateImagePaths, validateReferencedAssets, validateSVGFiles } from './validations/assets.js';
+import { validateImageDescriptions, validateImagePaths, validateReferencedAssets, validateSVGFiles, validateAssetsFolderName } from './validations/assets.js';
 import { validateSyntaxSpecifiers } from './validations/code-blocks.js';
 import { validateNestedLists } from './validations/lists.js';
 import { validateBrokenLinks } from './validations/links.js';
 import { ConfigManager } from './logic/config-manager.js';
 import { validateFolderName } from './validations/naming.js';
 
-export { Validator, ArticleManager, validateDuplicatedOpeningHeading, validateHeadingsNesting, validateMaxLength, validateNumberedHeadings, validateOpeningHeadingLevel, validateSpacing, validateTitleCase, validateMetaData, validateRules, validateImageDescriptions, validateImagePaths, validateReferencedAssets, validateSVGFiles, validateSyntaxSpecifiers, validateNestedLists, validateBrokenLinks, ConfigManager, validateFolderName }
+export { Validator, ArticleManager, validateDuplicatedOpeningHeading, validateHeadingsNesting, validateMaxLength, validateNumberedHeadings, validateOpeningHeadingLevel, validateSpacing, validateTitleCase, validateMetaData, validateRules, validateImageDescriptions, validateImagePaths, validateReferencedAssets, validateSVGFiles, validateAssetsFolderName, validateSyntaxSpecifiers, validateNestedLists, validateBrokenLinks, ConfigManager, validateFolderName }

--- a/validations/assets.js
+++ b/validations/assets.js
@@ -89,7 +89,8 @@ function validateSVGFiles(article){
  * @returns an array of ValidationIssue objects for the found issues.
  */
 function validateAssetsFolderName(article){
-    if(article.assets.length > 0 && article.assetsFolder === null){
+
+    if(article.assets.length > 0 && article.assetsFolder != "assets"){
         const errorMessage = "No standard assets directory found";
         return new ValidationIssue(errorMessage, article.contentFilePath, ValidationIssue.Type.WARNING);
     }


### PR DESCRIPTION
- Add new function to the export list
- `validateAssetsFolderName` fixed scenario: when it is null it does not mean the name is correct